### PR TITLE
Spanish translation

### DIFF
--- a/src/i8n/es-ES.json
+++ b/src/i8n/es-ES.json
@@ -1,0 +1,92 @@
+{
+    "es-ES": "Español (Spanish)",
+    "navigation": {
+        "home": "Inicio",
+        "explore": "Explorar",
+        "notifications": "Notificaciones",
+        "messages": "Mensajes Directos",
+        "user": "Perfil", "_comment": "You can also use the word 'Account' if it fits better in your language",
+        "settings": "Ajustes",
+        "signin": "Iniciar Sesión"
+    },
+
+    "timeline": {
+        "forYou": "Para tí",
+        "following": "Siguiendo",
+        "noneFollowing": "Si quieres usar la pestaña Siguiendo, debes seguir gente! 😝",
+        "like": "me gusta", "_comment": "This is an ammount. Example: 1 _like_",
+        "likes": "me gusta", "__comment": "'Likes' could also be 'me gustas' but it kinda sounds weird. Spanish is weird by itself",
+        "rechirp": "rechirp", "_comment": "This is an ammount. Example: 1 _rechirp_",
+        "rechirps": "rechirps",
+        "reply": "respuesta", "_comment": "This is an ammount. Example: 1 _reply_",
+        "replies": "respuestas"
+        
+    },
+
+    "details": {
+        "postedOn": "Publicado el",
+        "replyTo": "Responder a"
+    },  
+
+    "notifications": {
+        "allNotifications": "Todos",
+        "mentions": "Menciones",
+        "likedYourPost": "le ha gustado tu chirp",
+        "rechirpedYourPost": "rechirpeo tu chirp",
+        "quotedYourPost": "citó tu chirp",
+        "repliedToYourPost": "respondió a tu chirp",
+        "followedYou": "te ha seguido",
+        "and": "y",
+        "others": "otros"
+    },  
+
+    "messages": {
+        "findMessage": "Encontrar un mensaje...",
+        "noMessagesText": "¡Parece que no tienes mensajes!<br>¿Por qué no interactuas con alguien?"
+    },  
+
+    "search": {
+        "searchTitle": "Buscar",
+        "placeholderSearch": "¿Qué estas buscando?"
+    },  
+
+    "sideBar": {
+        "whoToFollow": "Cuentas sugeridas",
+        "trendsForYou": "Tendencias",
+        "highTraffic": "Estamos experimentando un alto flujo de trafico actualmente.<br>Chirpie esta haciendo lo mejor que puede, pero si Chirp se ralentiza, ¡no te preocupes!",
+        "legalFootnote": "Inspirado por Twitter/X. Ningún codigo ha sido tomado de Twitter/X. Twemoji por Twitter Inc/X Corp esta licenciado por CC-BY 4.0.<br>Estas usando: Chirp Beta 0.2.1b "
+    },
+
+    "time": {
+        "ago": "atrás",
+        "shortSeconds": "s",
+        "shortMinutes": "m",
+        "shortHours": "h",
+        "shortDays": "d"   
+    },
+
+
+    "buttons": { 
+        "cancel": "Cancelar", 
+        "chirpAction": "Chirp", "_comment": "This is a verb. Example: _Chirp_ this. Do not translate it to the sound a bird makes.", 
+        "likeAction": "Gustar", "_comment": "This is a verb. Example: _Like_ this post", 
+        "rechirpAction": "Rechirpear", "_comment": "This is a verb. Example: _Rechirp_ this post", 
+        "replyAction": "Responder", "_comment": "This is a verb. Example: _Reply_ to this tweet", 
+        "back": "Atrás", 
+        "searchAction": "Buscar",  
+        "advancedSearchAction": "Buscar de forma avanzada",
+        "edituser": "Editar perfil", 
+        "follow": "Seguir",
+        "following": "Siguiendo",
+        "edit": "Editar",
+        "editHistory": "Ver historial de ediciones",
+        "copyChirpText": "Copiar chirp",
+        "copyLink": "Copiar link",
+        "pinChirp": "Fijar chirp",
+        "broadcast": "Transmitir chirp", "__comment": "This is the literal translation, I can't get the exact one since I don't know what Broadcast does exactly",
+        "showHidden": "Mostrar respuestas ocultas",
+        "writeNote": "Escribir una nota de ChirpSees",
+        "muteConversation": "Silenciar conversación",
+        "delete": "Eliminar"
+    }
+}


### PR DESCRIPTION
**There are two comments on the 'likes' and 'broadcast' keys, since they are debatible on how the correct translation should be; It may need a little bit of retuning, but this is a good base for the translation.**

It still looks fine and it's easily understandable. I took some references from Twitter/X to correctly translate some keys like the "explore" one.

Chirp Username: JustNotSebas