### PR TITLE
Restyle application to look like Twitter

### DIFF
--- a/src/styles/menus.css
+++ b/src/styles/menus.css
@@ -3,13 +3,10 @@
     display: flex; /* Flex container */
     flex-direction: column; /* Stack items vertically */
     min-height: 100vh; /* Minimum height of viewport */
-    position: fixed; /* Fixed positioning */
-    top: 0; /* Align to the top */
-    right: 0; /* Align to the right */
-    padding-right: 5vw; /* Right padding */
     margin: 12px; /* Margin around the sidebar */
     margin-top: 24px; /* Top margin */
-    width: 20vw; /* Width of sidebar */
+    width: 350px;
+    margin-left: 24px;
 }
 
 /* Styles for items inside the sidebar */
@@ -26,7 +23,7 @@
     width: 100%; /* Full width */
     margin-bottom: 24px; /* Bottom margin */
     border-radius: 8px; /* Rounded corners */
-    background-color: #8b8b8b2d; /* Semi-transparent background */
+    background-color: #1A202C; /* Semi-transparent background */
 }
 
 /* Styles for paragraph elements inside the sidebar items */
@@ -74,14 +71,14 @@
 
 /* Styles for the header */
 header {
-    background-color: black;
+    background-color: #14171A;
     display: flex; /* Flex container */
     flex-direction: column; /* Stack items vertically */
     min-height: 100vh; /* Minimum height of viewport */
-    position: fixed; /* Fixed positioning */
     top: 0; /* Align to the top */
     left: 0; /* Align to the left */
-    margin-left: 13vw; /* Left margin */
+    width: 275px;
+    margin-right: 24px;
 }
 
 /* Styles for nested div elements inside the header */
@@ -95,7 +92,7 @@ header > div > nav {
 /* Styles for buttons inside the header */
 header > div > button {
     padding: 8px; /* Padding around the button */
-    background-color: black; /* Background color */
+    background-color: #14171A; /* Background color */
     border: none; /* No border */
     text-align: left; /* Left-aligned text */
     font-family: Jost, Arial, Helvetica, sans-serif; /* Font family */
@@ -107,7 +104,6 @@ header > div > button {
     flex-direction: row; /* Arrange items horizontally */
     border-radius: 24px; /* Rounded corners */
     transition: background-color 0.2s linear; /* Smooth background color transition */
-    position: absolute; /* Absolute positioning */
     bottom: 0; /* Align to the bottom */
 }
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -38,14 +38,14 @@
     --orange-hover: #D57100;
     --green: #1AD063;
     --green-hover: #128E3C; 
-    --blue: #10BDF3;
-    --blue-hover: #0A85BA; 
+    --blue: #1DA1F2;
+    --blue-hover: #1a91da;
     --purple: #7A2BFC;
     --purple-hover: #5B1ECC;
 
-    --accent-color: var(--green);
-    --hover-color: var(--green-hover);
-    --text-color: black;
+    --accent-color: var(--blue);
+    --hover-color: var(--blue-hover);
+    --text-color: white;
 }
 
 .showLayoutBounds *{
@@ -58,7 +58,7 @@ body,
 main,
 footer {
     font-family: Jost, Arial, Helvetica, sans-serif; /* Font family */
-    background-color: black; /* Background color */
+    background-color: #14171A; /* Background color */
     color: white; /* Text color */
     scroll-behavior: smooth; /* Smooth scrolling */
     color-scheme: dark; /* Dark color scheme */
@@ -147,6 +147,8 @@ a > img {
     margin-top: 4px; /* Top margin */
     text-align: center; /* Center alignment */
     color: var(--text-color); /* Text color */
+    border-radius: 9999px;
+    padding: 12px;
 }
 
 .newchirp:hover {
@@ -184,9 +186,9 @@ a > img {
     text-align: center; /* Center alignment */
     color: var(--text-color); /* Text color */
     border: none; /* No border */
-    border-radius: 8px; /* Border radius */
+    border-radius: 9999px; /* Border radius */
     font-size: 1em; /* Font size */
-    padding: 8px; /* Padding */
+    padding: 8px 16px; /* Padding */
     display: flex; /* Flex container */
     transition: .2s linear; /* Transition */
 }
@@ -261,7 +263,7 @@ main {
     display: flex; /* Flex container */
     flex-direction: column; /* Column direction */
     align-items: center; /* Center align items */
-    width: 100vw; /* Full width */
+    flex-grow: 1;
 }
 
 .title {
@@ -362,8 +364,8 @@ button.followButton, .button {
     margin-top: 4px; /* Top margin */
     text-align: center; /* Center alignment */
     color: var(--text-color); /* Text color */
-    border-radius: 8px; /* Border radius */
-    padding: 6px; /* Padding */
+    border-radius: 9999px; /* Border radius */
+    padding: 6px 16px; /* Padding */
     height: fit-content; /* Height based on content */
     font-size: 1em;
 }

--- a/src/styles/timeline.css
+++ b/src/styles/timeline.css
@@ -15,7 +15,6 @@
     /* Center-align items horizontally */
     justify-content: center;
     /* Center-align items vertically */
-    background-color: black;
 }
 
 /* Styles for elements with class 'chirp' */
@@ -24,14 +23,14 @@
     /* Padding around the chirp */
 
     /* Rounded corners */
-    font-family: Satoshi, Jost, Arial, Helvetica, sans-serif;
-    background-color: black;
-    /*border-bottom: 1px solid #8b8b8b2d;*/
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background-color: #14171A;
+    border-bottom: 1px solid #38444d;
 }
 
 
 .chirp:hover, .chir0pThread:hover, .draft:hover, .account:hover {
-    border-radius: 8px;
+    background-color: #1a202c;
 }
 
 .account {
@@ -263,13 +262,14 @@ img.verified, svg.verified {
 
 /* Styles for element with ID 'chirps' */
 div#chirps, div#posts,  div#replies {
-    border-left: #8b8b8b2d 1px solid;
+    border-left: 1px solid #38444d;
     /* Left border */
-    border-right: #8b8b8b2d 1px solid;
+    border-right: 1px solid #38444d;
     /* Right border */
-    border-bottom: #8b8b8b2d 1px solid;
+    border-bottom: 1px solid #38444d;
     /* Bottom border */
-    width: 35vw;
+    width: 100%;
+    max-width: 600px;
     /* 35% of viewport width */
 }
 
@@ -333,7 +333,8 @@ div.drafts-container {
     /* Sticky positioning */
     top: 0;
     /* Stick to the top */
-    background-color: #00000080;
+    background-color: rgba(20, 23, 26, 0.85);
+    backdrop-filter: blur(4px);
     /* Black background */
     z-index: 12;
     /* Stack order */
@@ -388,7 +389,7 @@ div.drafts-container {
     /* Padding */
     border: none;
     background-color: rgba(0, 0, 0, 0);
-    border-bottom: 1px rgb(56, 56, 56) solid;
+    border-bottom: 1px solid #38444d;
     font-size: 1em;
     /* Bottom border */
     border-top: none;
@@ -459,7 +460,7 @@ div.drafts-container {
     /* Full width */
     justify-content: space-between;
     /* Space items evenly */
-    border-top: 1px rgb(56, 56, 56) solid;
+    border-top: 1px solid #38444d;
     /* Top border */
 }
 
@@ -479,17 +480,17 @@ div.drafts-container {
     margin-top: 12px;
     /* Top margin */
     /* Smooth transition */
-    color: white;
+    color: #657786;
     /* Text color */
     border-radius: 8px;
     /* Rounded corners */
-    color: #6b6b6b;
     transition: .2s linear;
 }
 
 /* Styles for buttons within 'chirpInteract' on hover */
 .chirpInteract>button:hover {
-    background-color: #6b6b6b4f;
+    background-color: rgba(29, 161, 242, 0.1);
+    color: #1DA1F2;
     /* Semi-transparent background on hover */
     cursor: pointer;
     /* Cursor pointer on hover */


### PR DESCRIPTION
This commit updates the application's CSS to give it a visual style similar to Twitter.

Key changes include:
- Updated color scheme to Twitter's blue and dark gray palette.
- Implemented a three-column layout for the main page.
- Restyled "chirps" to resemble tweets, with bottom borders and a new font.
- Updated buttons to be pill-shaped.